### PR TITLE
Handle ConnectionState.FAILED during login phase

### DIFF
--- a/android/src/main/java/org/xrstudio/xmpp/flutter_xmpp/FlutterXmppPlugin.java
+++ b/android/src/main/java/org/xrstudio/xmpp/flutter_xmpp/FlutterXmppPlugin.java
@@ -774,7 +774,8 @@ public class FlutterXmppPlugin implements MethodCallHandler, FlutterPlugin, Acti
     // login
     private void doLogin() {
         // Check if the user is already connected or not ? if not then start login process.
-        if (FlutterXmppConnectionService.getState().equals(ConnectionState.DISCONNECTED)) {
+        final ConnectionState connState = FlutterXmppConnectionService.getState();
+        if (connState.equals(ConnectionState.DISCONNECTED) || connState.equals(ConnectionState.FAILED)) {
             Intent i = new Intent(activity, FlutterXmppConnectionService.class);
             i.putExtra(Constants.JID_USER, jid_user);
             i.putExtra(Constants.PASSWORD, password);


### PR DESCRIPTION
Fixes #129.

When a first login attempt fails, the connection state of the ConnectionService is set to FAILED, and it doesn't change. If a new login is performed, the doLogin method simply returns, as only the DISCONNECTED state is handled.

FAILED is now taken into account as well.